### PR TITLE
Ci/additional-major-version

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -309,6 +309,7 @@ extends:
                   publishFeedCredentials: 'OpenAPI Nuget Connection'
 
       - deployment: create_github_release
+        condition: and(contains(variables['build.SourceBranch'], 'refs/tags/v'), succeeded())
         templateContext:
           type: releaseJob
           isProduction: true

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -7,6 +7,7 @@ trigger:
     include:
     - main
     - support/v1
+    - support/v2
   tags:
     include:
     - 'v*'
@@ -15,6 +16,7 @@ pr:
     include:
     - main
     - support/v1
+    - support/v2
 
 variables:
   buildPlatform: 'Any CPU'

--- a/.github/policies/OpenAPI.NET-branch-protection.yml
+++ b/.github/policies/OpenAPI.NET-branch-protection.yml
@@ -81,3 +81,39 @@ configuration:
       # Restrict who can dismiss pull request reviews. boolean
       restrictsReviewDismissals: false
 
+    - branchNamePattern: support/v2
+      # This branch pattern applies to the following branches as of approximately 02/27/2025 15:28:20:
+      # support/v1
+
+      # Specifies whether this branch can be deleted. boolean
+      allowsDeletions: false
+      # Specifies whether forced pushes are allowed on this branch. boolean
+      allowsForcePushes: false
+      # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+      dismissStaleReviews: true
+      # Specifies whether admins can overwrite branch protection. boolean
+      isAdminEnforced: true
+      # Indicates whether "Require a pull request before merging" is enabled. boolean
+      requiresPullRequestBeforeMerging: true
+      # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
+      requiredApprovingReviewsCount: 1
+      # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+      requireCodeOwnersReview: true
+      # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
+      requiresCommitSignatures: false
+      # Are conversations required to be resolved before merging? boolean
+      requiresConversationResolution: true
+      # Are merge commits prohibited from being pushed to this branch. boolean
+      requiresLinearHistory: false
+      # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+      requiredStatusChecks:
+      - license/cla
+      - CodeQL
+      - Continuous Integration
+      # Require branches to be up to date before merging. boolean
+      requiresStrictStatusChecks: false
+      # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
+      restrictsPushes: false
+      # Restrict who can dismiss pull request reviews. boolean
+      restrictsReviewDismissals: false
+

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -5,3 +5,6 @@ branches:
   - branch: support/v1
     manifest: true
     handleGHRelease: true
+  - branch: support/v2
+    manifest: true
+    handleGHRelease: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: CodeQL Analysis
 
 on:
   push:
-    branches: [ main, support/v1 ]
+    branches: [ main, support/v1, support/v2 ]
   pull_request:
   schedule:
     - cron: '0 8 * * *'

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - main
       - support/v1
+      - support/v2
 
 jobs:
   release:


### PR DESCRIPTION
This pull requests sets up for CI for an additional major version branch since a lot of the changes for 3.2 are binary breaking and will require a new major version.